### PR TITLE
Add write(String str) function to FTDriver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 *.jar
 
 # android
+bin
+gen
 *.dex
 *.ap_
 R.java

--- a/FTDriver/src/jp/ksksue/driver/serial/FTDriver.java
+++ b/FTDriver/src/jp/ksksue/driver/serial/FTDriver.java
@@ -379,12 +379,7 @@ public class FTDriver {
      * @return written length
      */
     public int write(String str) {
-        char[] charArray = str.toCharArray();
-        byte outBuf[] = new byte[charArray.length];
-        for (int i = 0; i < str.length(); i++) {
-            outBuf[i] = (byte) charArray[i];
-        }
-        return write(outBuf);
+        return write(str.getBytes());
     }
     
     /**

--- a/FTDriver/src/jp/ksksue/driver/serial/FTDriver.java
+++ b/FTDriver/src/jp/ksksue/driver/serial/FTDriver.java
@@ -372,6 +372,21 @@ public class FTDriver {
         return ofst;
     }
 
+    /** 
+     * Writes a Complete String
+     * 
+     * @param str : outgoing string
+     * @return written length
+     */
+    public int write(String str) {
+        char[] charArray = str.toCharArray();
+        byte outBuf[] = new byte[charArray.length];
+        for (int i = 0; i < str.length(); i++) {
+            outBuf[i] = (byte) charArray[i];
+        }
+        return write(outBuf);
+    }
+    
     /**
      * Writes 1byte Binary Data
      * 
@@ -387,7 +402,7 @@ public class FTDriver {
      * 
      * @param buf : write buffer
      * @param length : write length
-     * @return wrriten length
+     * @return written length
      */
     public int write(byte[] buf, int length) {
         return write(buf, length, 0);


### PR DESCRIPTION
The added `write(String str)` function takes an input string, creates a new buffer, and then uses the `write(byte[] buf)` function. 

I also corrected one typo that I saw.
